### PR TITLE
Project name now contains spaces.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           extra-files: |
             database.dbml
+            prepend.py
+            shift.py
             README.md
           pull-request-title-pattern: "chore${scope}: release${component} v${version}"
           package-name: "open-discogs-erd"

--- a/prepend.py
+++ b/prepend.py
@@ -22,7 +22,7 @@ def get_prepend(name, db_type, readme):
 {}
 \'\'\'
 }}
-'''.format(name.strip().replace(' ', ''), db_type.strip(), readme.strip())
+'''.format(name.strip(), db_type.strip(), readme.strip())
 
 def get_indent(depth):
     return '    '*depth


### PR DESCRIPTION
Project name natively supports name with spaces within; hence only strip is required, not replace.